### PR TITLE
added wait for transmission of pms commands

### DIFF
--- a/src/PMS.cpp
+++ b/src/PMS.cpp
@@ -11,6 +11,7 @@ void PMS::sleep()
 {
   uint8_t command[] = { 0x42, 0x4D, 0xE4, 0x00, 0x00, 0x01, 0x73 };
   _stream->write(command, sizeof(command));
+  _stream->flush();
 }
 
 // Operating mode. Stable data should be got at least 30 seconds after the sensor wakeup from the sleep mode because of the fan's performance.
@@ -18,6 +19,7 @@ void PMS::wakeUp()
 {
   uint8_t command[] = { 0x42, 0x4D, 0xE4, 0x00, 0x01, 0x01, 0x74 };
   _stream->write(command, sizeof(command));
+  _stream->flush();
 }
 
 // Active mode. Default mode after power up. In this mode sensor would send serial data to the host automatically.
@@ -25,6 +27,7 @@ void PMS::activeMode()
 {
   uint8_t command[] = { 0x42, 0x4D, 0xE1, 0x00, 0x01, 0x01, 0x71 };
   _stream->write(command, sizeof(command));
+  _stream->flush();
   _mode = MODE_ACTIVE;
 }
 
@@ -33,6 +36,7 @@ void PMS::passiveMode()
 {
   uint8_t command[] = { 0x42, 0x4D, 0xE1, 0x00, 0x00, 0x01, 0x70 };
   _stream->write(command, sizeof(command));
+  _stream->flush();
   _mode = MODE_PASSIVE;
 }
 
@@ -43,6 +47,7 @@ void PMS::requestRead()
   {
     uint8_t command[] = { 0x42, 0x4D, 0xE2, 0x00, 0x00, 0x01, 0x71 };
     _stream->write(command, sizeof(command));
+    _stream->flush();
   }
 }
 


### PR DESCRIPTION
Happy that I've came across this library, nice work!
Although, really struggled to get the active/passive modes working on a ESP32-WROOM-32D, until I realised that we need to wait for the transmit buffer to be emptied. Hope this helps others with the same problem..