### PR TITLE
Add support for particle counts, backwards compatible with PMSx003

### DIFF
--- a/examples/Advanced/Advanced.ino
+++ b/examples/Advanced/Advanced.ino
@@ -30,6 +30,22 @@ void loop()
 
     Serial1.print("PM 10.0 (ug/m3): ");
     Serial1.println(data.PM_AE_UG_10_0);
+
+    if (data.hasParticles)
+    {
+        Serial1.print("Particles > 0.3um: ");
+        Serial1.println(data.PM_TOTALPARTICLES_0_3);
+        Serial1.print("Particles > 0.5um: ");
+        Serial1.println(data.PM_TOTALPARTICLES_0_5);
+        Serial1.print("Particles > 1.0um: ");
+        Serial1.println(data.PM_TOTALPARTICLES_1_0);
+        Serial1.print("Particles > 2.5um: ");
+        Serial1.println(data.PM_TOTALPARTICLES_2_5);
+        Serial1.print("Particles > 5.0um: ");
+        Serial1.println(data.PM_TOTALPARTICLES_5_0);
+        Serial1.print("Particles > 10.0um: ");
+        Serial1.println(data.PM_TOTALPARTICLES_10_0);
+    }
   }
   else
   {

--- a/src/PMS.cpp
+++ b/src/PMS.cpp
@@ -133,8 +133,22 @@ void PMS::loop()
           _data->PM_AE_UG_1_0 = makeWord(_payload[6], _payload[7]);
           _data->PM_AE_UG_2_5 = makeWord(_payload[8], _payload[9]);
           _data->PM_AE_UG_10_0 = makeWord(_payload[10], _payload[11]);
-        }
 
+          // Total particles
+          uint8_t dataWords = _frameLen/2 - 1; // subtract checksum
+          if (dataWords >= 12) {
+            _data->PM_TOTALPARTICLES_0_3 = makeWord(_payload[12], _payload[13]);
+            _data->PM_TOTALPARTICLES_0_5 = makeWord(_payload[14], _payload[15]);
+            _data->PM_TOTALPARTICLES_1_0 = makeWord(_payload[16], _payload[17]);
+            _data->PM_TOTALPARTICLES_2_5 = makeWord(_payload[18], _payload[19]);
+            _data->PM_TOTALPARTICLES_5_0 = makeWord(_payload[20], _payload[21]);
+            _data->PM_TOTALPARTICLES_10_0 = makeWord(_payload[22], _payload[23]);
+            _data->hasParticles = true;
+          }
+          else {
+            _data->hasParticles = false;
+          }
+        }
         _index = 0;
         return;
       }
@@ -143,7 +157,6 @@ void PMS::loop()
         _calculatedChecksum += ch;
         uint8_t payloadIndex = _index - 4;
 
-        // Payload is common to all sensors (first 2x6 bytes).
         if (payloadIndex < sizeof(_payload))
         {
           _payload[payloadIndex] = ch;

--- a/src/PMS.h
+++ b/src/PMS.h
@@ -22,6 +22,15 @@ public:
     uint16_t PM_AE_UG_1_0;
     uint16_t PM_AE_UG_2_5;
     uint16_t PM_AE_UG_10_0;
+
+    // Total particles
+    uint16_t PM_TOTALPARTICLES_0_3;
+    uint16_t PM_TOTALPARTICLES_0_5;
+    uint16_t PM_TOTALPARTICLES_1_0;
+    uint16_t PM_TOTALPARTICLES_2_5;
+    uint16_t PM_TOTALPARTICLES_5_0;
+    uint16_t PM_TOTALPARTICLES_10_0;
+    bool hasParticles;
   };
 
   PMS(Stream&);
@@ -38,7 +47,7 @@ private:
   enum STATUS { STATUS_WAITING, STATUS_OK };
   enum MODE { MODE_ACTIVE, MODE_PASSIVE };
 
-  uint8_t _payload[12];
+  uint8_t _payload[24];
   Stream* _stream;
   DATA* _data;
   STATUS _status;


### PR DESCRIPTION
This is a rewrite of #7 which should fix #8 in a better way:

* Checks frame length and only populates the particle fields when large frames are received
* Adds a boolean indicating if the particles fields were populated
* Modifies the Advanced example to show how to use this

Tested on PMS5003 in both active and passive mode.